### PR TITLE
Fix knowledge search filtering logic

### DIFF
--- a/src/crewai/knowledge/storage/knowledge_storage.py
+++ b/src/crewai/knowledge/storage/knowledge_storage.py
@@ -77,7 +77,7 @@ class KnowledgeStorage(BaseKnowledgeStorage):
                         "context": fetched["documents"][0][i],  # type: ignore
                         "score": fetched["distances"][0][i],  # type: ignore
                     }
-                    if result["score"] >= score_threshold:
+                    if result["score"] <= score_threshold:
                         results.append(result)
                 return results
             else:

--- a/tests/knowledge/test_knowledge_storage_filter.py
+++ b/tests/knowledge/test_knowledge_storage_filter.py
@@ -1,0 +1,20 @@
+from crewai.knowledge.storage.knowledge_storage import KnowledgeStorage
+from unittest.mock import patch
+
+class DummyCollection:
+    def query(self, query_texts, n_results, where=None):
+        return {
+            "ids": [["1", "2", "3"]],
+            "metadatas": [[{"idx": 1}, {"idx": 2}, {"idx": 3}]],
+            "documents": [["doc1", "doc2", "doc3"]],
+            "distances": [[0.1, 0.5, 0.7]],
+        }
+
+
+def test_search_filters_by_score_threshold():
+    with patch.object(KnowledgeStorage, "_set_embedder_config"):
+        storage = KnowledgeStorage()
+    storage.collection = DummyCollection()
+    results = storage.search(["query"], limit=3, score_threshold=0.5)
+    scores = [r["score"] for r in results]
+    assert scores == [0.1, 0.5]


### PR DESCRIPTION
## Summary
- fix KnowledgeStorage to filter by distance instead of similarity
- test filtering threshold behaviour

## Testing
- `ruff check tests/knowledge/test_knowledge_storage_filter.py src/crewai/knowledge/storage/knowledge_storage.py`
- `pytest tests/knowledge/test_knowledge_storage_filter.py -q`
- `pytest tests/agent_test.py::test_agent_creation -q`


------
https://chatgpt.com/codex/tasks/task_e_686b1f79ea98832fa1e43a1b8ff390a4